### PR TITLE
feat: add support of rate-limit reset as metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ You can up the rate limit to *15,000* with an enterprise account but the problem
 *If your service/program needs to make consistent and/or sustained requests to Github's APIs,</br>
 you will have to work around and make the most of Github's rate limits.*
 
-So, the *Prometheus Github rate-limits exporter* was introduced to expose the *remaining*, *used* and *limit*</br>
-(quotas) information per Github API as metrics in order to create alerting events and (Grafana) monitoring dashboards.
+So, the *Prometheus Github rate-limits exporter* was introduced to expose the *remaining*, *used*, *limit*</br>
+(quotas) and *reset* (rate-limit window resets in UTC seconds) information per Github API as metrics in order</br>
+to create alerting events and (Grafana) monitoring dashboards.
 
 For the exporter to fetch and expose the Github API rate-limits, you need to supply:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       context: ./
       dockerfile: ./Dockerfile
     image: prom-gh-rl-exporter:latest
+    restart: on-failure:5
     expose:
       - 10050
     ports:
@@ -79,6 +80,25 @@ services:
     command: --config.file=/etc/alertmanager/alertmanager.yml
     networks:
       - monitoring
+
+  portainer:
+    hostname: dashboard
+    container_name: portainer
+    image: portainer/portainer-ce:2.16.2
+    expose:
+      - 9443
+    ports:
+      - "9443:9443"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - portainer_data:/data
+    command: -H unix:///var/run/docker.sock
+    networks:
+      - monitoring
+
+volumes:
+  portainer_data:
+
 
 networks:
   monitoring:

--- a/github_rate_limits_exporter/collector.py
+++ b/github_rate_limits_exporter/collector.py
@@ -119,4 +119,7 @@ class GithubRateLimitsCollector(Collector):
         gauge.add_metric(
             [self._account, "remaining"], float(limits.remaining), get_unix_timestamp()
         )
+        gauge.add_metric(
+            [self._account, "reset"], float(limits.reset), get_unix_timestamp()
+        )
         return gauge

--- a/github_rate_limits_exporter/constants.py
+++ b/github_rate_limits_exporter/constants.py
@@ -8,4 +8,4 @@
 import dotmap
 
 DEFAULT_LOG_FMT = "[%(levelname)s - %(asctime)s]: %(message)s"
-DEFAULT_RATE_LIMITS = dotmap.DotMap(limit=0.0, used=0.0, remaining=0.0)
+DEFAULT_RATE_LIMITS = dotmap.DotMap(limit=0.0, used=0.0, remaining=0.0, reset=0.0)

--- a/monitoring/grafana/dashboards/sample.json
+++ b/monitoring/grafana/dashboards/sample.json
@@ -32,11 +32,17 @@
         "type": "prometheus",
         "uid": "PBFA97CFB590B2093"
       },
-      "description": "Grafana dashboard to monitor Github GraphQL API Rate Limits",
+      "description": "The time at which the current Github API Rate Limit window resets.",
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "continuous-RdYlGr"
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "center",
+            "displayMode": "color-text",
+            "filterable": false,
+            "inspect": false
           },
           "mappings": [],
           "thresholds": {
@@ -57,14 +63,24 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "GraphQL API - used"
+              "options": "Value"
             },
             "properties": [
               {
-                "id": "color",
-                "value": {
-                  "mode": "continuous-GrYlRd"
-                }
+                "id": "displayName",
+                "value": "DateTime"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Time"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
               }
             ]
           }
@@ -76,29 +92,23 @@
         "x": 0,
         "y": 0
       },
-      "id": 6,
+      "id": 10,
       "links": [
         {
-          "title": "github-graphql-api-rate-limits",
-          "url": "https://docs.github.com/en/graphql"
+          "title": "Github-API-Rate-Limits-Reset Timestamp",
+          "url": "https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28"
         }
       ],
       "options": {
-        "displayMode": "gradient",
-        "minVizHeight": 10,
-        "minVizWidth": 0,
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+        "footer": {
           "fields": "",
-          "values": false
+          "reducer": [
+            "sum"
+          ],
+          "show": false
         },
-        "showUnfilled": true,
-        "text": {
-          "titleSize": 20
-        }
+        "showHeader": true,
+        "sortBy": []
       },
       "pluginVersion": "9.2.4",
       "targets": [
@@ -109,16 +119,32 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "github_rate_limits_graphql{account=\"$account\"}",
-          "instant": false,
-          "legendFormat": "GraphQL API - {{type}}",
-          "range": true,
+          "expr": "label_join(sum by (__name__) ({type=\"reset\"}), \"Metric\", \"\", \"__name__\") * 1000",
+          "format": "table",
+          "instant": true,
+          "interval": "30",
+          "legendFormat": "{{label_name}}",
+          "range": false,
           "refId": "A"
         }
       ],
-      "title": "Github GraphQL API Rate Limits",
+      "title": "Github API Rate Limits (Time to) Reset",
+      "transformations": [
+        {
+          "id": "convertFieldType",
+          "options": {
+            "conversions": [
+              {
+                "destinationType": "time",
+                "targetField": "Value"
+              }
+            ],
+            "fields": {}
+          }
+        }
+      ],
       "transparent": true,
-      "type": "bargauge"
+      "type": "table"
     },
     {
       "datasource": {
@@ -200,7 +226,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "github_rate_limits_integration_manifest{account=\"$account\"}",
+          "expr": "github_rate_limits_integration_manifest{account=\"$account\", type=~\"limit|remaining|used\"}",
           "legendFormat": "Integrate Manifest API - {{type}}",
           "range": true,
           "refId": "A"
@@ -215,24 +241,23 @@
         "type": "prometheus",
         "uid": "PBFA97CFB590B2093"
       },
-      "description": "Grafana dashboard to monitor Github Search API Rate Limits",
+      "description": "Grafana dashboard to monitor Github GraphQL API Rate Limits",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "continuous-RdYlGr"
           },
-          "custom": {
-            "fillOpacity": 16,
-            "lineWidth": 6,
-            "spanNulls": false
-          },
           "mappings": [],
           "thresholds": {
-            "mode": "percentage",
+            "mode": "absolute",
             "steps": [
               {
                 "color": "green",
                 "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
               }
             ]
           }
@@ -241,7 +266,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "Search API - used"
+              "options": "GraphQL API - used"
             },
             "properties": [
               {
@@ -260,26 +285,28 @@
         "x": 0,
         "y": 8
       },
-      "id": 4,
+      "id": 6,
       "links": [
         {
-          "title": "github-search-api-rate-limits",
-          "url": "https://docs.github.com/en/rest/search"
+          "title": "github-graphql-api-rate-limits",
+          "url": "https://docs.github.com/en/graphql"
         }
       ],
       "options": {
-        "alignValue": "center",
-        "legend": {
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
+        "displayMode": "gradient",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
         },
-        "mergeValues": true,
-        "rowHeight": 0.91,
-        "showValue": "always",
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
+        "showUnfilled": true,
+        "text": {
+          "titleSize": 20
         }
       },
       "pluginVersion": "9.2.4",
@@ -290,14 +317,17 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "github_rate_limits_search{account=\"$account\"}",
-          "legendFormat": "Search API - {{type}}",
+          "exemplar": false,
+          "expr": "github_rate_limits_graphql{account=\"$account\", type=~\"limit|remaining|used\"}",
+          "instant": false,
+          "legendFormat": "GraphQL API - {{type}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Github Search API Rate Limits",
-      "type": "state-timeline"
+      "title": "Github GraphQL API Rate Limits",
+      "transparent": true,
+      "type": "bargauge"
     },
     {
       "datasource": {
@@ -374,7 +404,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "github_rate_limits_core{account=\"$account\"}",
+          "expr": "github_rate_limits_core{account=\"$account\", type=~\"limit|remaining|used\"}",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -386,6 +416,95 @@
       "title": "Github Core API Rate Limits",
       "transparent": true,
       "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "Grafana dashboard to monitor Github Search API Rate Limits",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-RdYlGr"
+          },
+          "custom": {
+            "fillOpacity": 16,
+            "lineWidth": 6,
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Search API - used"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "continuous-GrYlRd"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 4,
+      "links": [
+        {
+          "title": "github-search-api-rate-limits",
+          "url": "https://docs.github.com/en/rest/search"
+        }
+      ],
+      "options": {
+        "alignValue": "center",
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "mergeValues": true,
+        "rowHeight": 0.91,
+        "showValue": "always",
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.2.4",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "github_rate_limits_search{account=\"$account\", type=~\"limit|remaining|used\"}",
+          "legendFormat": "Search API - {{type}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Github Search API Rate Limits",
+      "type": "state-timeline"
     }
   ],
   "refresh": "10s",

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -20,11 +20,12 @@ def test_add_metrics(collector, rate_limits_json, mocker):
     expected_metric.add_metric(['github_account','limit'], float(30), CURRENT_TIMESTAMP)
     expected_metric.add_metric(['github_account','used'], float(12), CURRENT_TIMESTAMP)
     expected_metric.add_metric(['github_account','remaining'], float(18), CURRENT_TIMESTAMP)
+    expected_metric.add_metric(['github_account', 'reset'], float(1372697452), CURRENT_TIMESTAMP)
     actual_metric = collector._add_metric(
         api_name='search',
         resources=mock_resources
     )
-    assert mock_unix_timestamp.call_count == 3
+    assert mock_unix_timestamp.call_count == 4
     assert actual_metric == expected_metric
 
 
@@ -49,6 +50,7 @@ def test_collect_metrics(collector, mock_rate_limits, mocker):
     core.add_metric(['github_account','limit'], float(5000), CURRENT_TIMESTAMP)
     core.add_metric(['github_account','used'], float(1), CURRENT_TIMESTAMP)
     core.add_metric(['github_account','remaining'], float(4999), CURRENT_TIMESTAMP)
+    core.add_metric(['github_account', 'reset'], float(1372700873), CURRENT_TIMESTAMP)
 
     search = GaugeMetricFamily(
         'github_rate_limits_search',
@@ -58,6 +60,7 @@ def test_collect_metrics(collector, mock_rate_limits, mocker):
     search.add_metric(['github_account','limit'], float(30), CURRENT_TIMESTAMP)
     search.add_metric(['github_account','used'], float(12), CURRENT_TIMESTAMP)
     search.add_metric(['github_account','remaining'], float(18), CURRENT_TIMESTAMP)
+    search.add_metric(['github_account', 'reset'], float(1372697452), CURRENT_TIMESTAMP)
 
     graphql = GaugeMetricFamily(
         'github_rate_limits_graphql',
@@ -67,6 +70,7 @@ def test_collect_metrics(collector, mock_rate_limits, mocker):
     graphql.add_metric(['github_account','limit'], float(5000), CURRENT_TIMESTAMP)
     graphql.add_metric(['github_account','used'], float(7), CURRENT_TIMESTAMP)
     graphql.add_metric(['github_account','remaining'], float(4993), CURRENT_TIMESTAMP)
+    graphql.add_metric(['github_account', 'reset'], float(1372700389), CURRENT_TIMESTAMP)
 
     integration_manifest = GaugeMetricFamily(
         'github_rate_limits_integration_manifest',
@@ -76,6 +80,7 @@ def test_collect_metrics(collector, mock_rate_limits, mocker):
     integration_manifest.add_metric(['github_account','limit'], float(5000), CURRENT_TIMESTAMP)
     integration_manifest.add_metric(['github_account','used'], float(1), CURRENT_TIMESTAMP)
     integration_manifest.add_metric(['github_account','remaining'], float(4999), CURRENT_TIMESTAMP)
+    integration_manifest.add_metric(['github_account', 'reset'], float(1551806725), CURRENT_TIMESTAMP)
 
     code_scanning_upload = GaugeMetricFamily(
         'github_rate_limits_code_scanning_upload',
@@ -85,6 +90,7 @@ def test_collect_metrics(collector, mock_rate_limits, mocker):
     code_scanning_upload.add_metric(['github_account','limit'], float(500), CURRENT_TIMESTAMP)
     code_scanning_upload.add_metric(['github_account','used'], float(20), CURRENT_TIMESTAMP)
     code_scanning_upload.add_metric(['github_account','remaining'], float(480), CURRENT_TIMESTAMP)
+    code_scanning_upload.add_metric(['github_account', 'reset'], float(1551806725), CURRENT_TIMESTAMP)
 
     expected_metrics = [
         core, search, graphql,
@@ -93,7 +99,7 @@ def test_collect_metrics(collector, mock_rate_limits, mocker):
     ]
 
     assert collector.collect() == expected_metrics
-    assert mock_unix_timestamp.call_count == 15
+    assert mock_unix_timestamp.call_count == 20
     assert mock_rate_limits.call_count == 1
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,24 @@ requires =
   virtualenv>20
 
 
+[base]
+passenv =
+    GITHUB_ACCOUNT
+    GITHUB_AUTH_TYPE
+    GITHUB_TOKEN
+    GITHUB_APP_ID
+    GITHUB_APP_INSTALLATION_ID
+    GITHUB_APP_PRIVATE_KEY_PATH
+    GITHUB_APP_SRC_PRIVATE_KEY_PATH
+
+
+[dc-base]
+passenv =
+    {[base]passenv}
+    GF_SECURITY_ADMIN_USER
+    GF_SECURITY_ADMIN_PASSWORD
+
+
 [testenv]
 changedir = {toxinidir}
 basepython = python3
@@ -87,14 +105,7 @@ commands =
 [testenv:dc]
 description = Docker-compose command line
 depend = pre-testenv
-passenv =
-    GITHUB_ACCOUNT
-    GITHUB_AUTH_TYPE
-    GITHUB_TOKEN
-    GITHUB_APP_ID
-    GITHUB_APP_INSTALLATION_ID
-    GITHUB_APP_PRIVATE_KEY_PATH
-    GITHUB_APP_SRC_PRIVATE_KEY_PATH
+passenv = {[dc-base]passenv}
 deps =
     -r {toxinidir}/requirements.d/dc.txt
 commands =
@@ -103,16 +114,7 @@ commands =
 
 [testenv:dc-run]
 description = Docker-compose setup and run all services
-passenv =
-    GITHUB_ACCOUNT
-    GITHUB_AUTH_TYPE
-    GITHUB_TOKEN
-    GITHUB_APP_ID
-    GITHUB_APP_INSTALLATION_ID
-    GITHUB_APP_PRIVATE_KEY_PATH
-    GITHUB_APP_SRC_PRIVATE_KEY_PATH
-    GF_SECURITY_ADMIN_USER
-    GF_SECURITY_ADMIN_PASSWORD
+passenv = {[dc-base]passenv}
 deps =
     -r {toxinidir}/requirements.d/dc.txt
 commands =
@@ -121,16 +123,7 @@ commands =
 
 [testenv:dc-clean]
 description = Docker-compose cleanup/teardown all services
-passenv =
-    GITHUB_ACCOUNT
-    GITHUB_AUTH_TYPE
-    GITHUB_TOKEN
-    GITHUB_APP_ID
-    GITHUB_APP_INSTALLATION_ID
-    GITHUB_APP_PRIVATE_KEY_PATH
-    GITHUB_APP_SRC_PRIVATE_KEY_PATH
-    GF_SECURITY_ADMIN_USER
-    GF_SECURITY_ADMIN_PASSWORD
+passenv = {[dc-base]passenv}
 deps =
     -r {toxinidir}/requirements.d/dc.txt
 commands =
@@ -171,14 +164,7 @@ commands =
 
 [testenv:run]
 description = Start prometheus exporter as service
-passenv =
-    GITHUB_ACCOUNT
-    GITHUB_AUTH_TYPE
-    GITHUB_TOKEN
-    GITHUB_APP_ID
-    GITHUB_APP_INSTALLATION_ID
-    GITHUB_APP_PRIVATE_KEY_PATH
-    GITHUB_APP_SRC_PRIVATE_KEY_PATH
+passenv = {[base]passenv}
 commands =
     {envpython} -m github_rate_limits_exporter {posargs}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

Add the x-rate-limit reset header as prometheus metric, it is the time which the current rate-limit window resets in UTC epoch seconds. Update Grafana sample dashboard to include a table with the reset datetime for all the Github API rate-limits.

#### Related Issues
<!--- Does this relate to any issues? -->
Addresses 
