### PR TITLE
ci: add Trivys vulnerability scanner in github action steps

### DIFF
--- a/.github/workflows/container-build-test-and-publish.yml
+++ b/.github/workflows/container-build-test-and-publish.yml
@@ -93,6 +93,15 @@ jobs:
             -timeout ${{ env.DOCKER_GITHUB_RL_TIMEOUT }}
             -wait-retry-interval ${{ env.DOCKER_GITHUB_RL_INTERVAL }}
 
+      - name: "Run Trivy vulnerability scanner on docker container image"
+        uses: "aquasecurity/trivy-action@v0.8.0"
+        with:
+          image-ref: "${{ env.DOCKERHUB_NAMESPACE }}:${{ env.DOCKER_TAG }}"
+          format: "table"
+          exit-code: "1"
+          ignore-unfixed: true
+          severity: "HIGH,CRITICAL"
+
       - name: "Push the docker container image"
         uses: "docker/build-push-action@v3.2.0"
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,14 +8,20 @@ ENV PATH="/opt/venv/bin:$PATH"
 # Requirements in separate stage
 FROM build as build-env
 
+RUN python3 -m pip install -U setuptools
+
 COPY requirements.txt ./
+
+ARG PIP_DISABLE_PIP_VERSION_CHECK=1
+ARG PIP_NO_COMPILE=1
+ENV PYTHON_PIP_VERSION=22.3.1
+ENV PYTHON_SETUPTOOLS_VERSION=65.5.1
 
 # Buildkits caching
 RUN --mount=type=cache,target=/root/.cache/ \
-      python3 -m pip install \
-      --no-compile \
-      --disable-pip-version-check \
-      -r requirements.txt
+      python3 -m pip install -U pip==${PYTHON_PIP_VERSION} && \
+      python3 -m pip install -U setuptools==${PYTHON_SETUPTOOLS_VERSION} && \
+      python3 -m pip install -r requirements.txt
 
 FROM python:3.11.1-slim AS run
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
add trivy as security vulnerability scanner as extra test step in docker image testing stage, fix vulnerability CVE-2022-40897 due to trivy vulnerability scanner reporting

<!--- Describe your changes in detail -->

#### Related Issues
<!--- Does this relate to any issues? -->
Addresses 
