### PR TITLE
feat: make exporter log level configurable

### DIFF
--- a/.github/workflows/container-build-test-and-publish.yml
+++ b/.github/workflows/container-build-test-and-publish.yml
@@ -97,7 +97,6 @@ jobs:
         uses: "aquasecurity/trivy-action@0.8.0"
         with:
           image-ref: "${{ env.DOCKERHUB_NAMESPACE }}:${{ env.DOCKER_TAG }}"
-          format: "table"
           exit-code: "1"
           ignore-unfixed: true
           severity: "HIGH,CRITICAL"

--- a/.github/workflows/linting-and-testing.yml
+++ b/.github/workflows/linting-and-testing.yml
@@ -41,3 +41,13 @@ jobs:
         uses: "hadolint/hadolint-action@v3.0.0"
         with:
           failure-threshold: error
+
+      - name: "Run Trivys"
+        uses: "aquasecurity/trivy-action@0.8.0"
+        with:
+          scan-type: fs
+          scan-ref: Dockerfile
+          exit-code: 1
+          ignore-unfixed: true
+          severity: CRITICAL,HIGH
+          security-checks: vuln,secret,config

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,4 +40,4 @@ ENV PYTHONUNBUFFERED=1
 
 EXPOSE 10050
 
-ENTRYPOINT ["python", "-m", "github_rate_limits_exporter", "-vvv"]
+ENTRYPOINT ["python", "-m", "github_rate_limits_exporter"]

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ pip install --user tox
 ### Run as ``PAT`` Github authentication type
 
 ```bash
-tox -e run -- \
+tox -e run-exporter -- \
   --github-auth-type pat \
   --github-account my_account_name \
   --github-token my_token
@@ -60,7 +60,7 @@ tox -e run -- \
 ### Run as ``APP`` (Github App) Github authentication type
 
 ```bash
-tox -e run -- \
+tox -e run-exporter -- \
   --github-auth-type app \
   --github-account my_account_name \
   --github-app-id my_app_id \
@@ -90,6 +90,7 @@ docker run -p 10050:10050 -d \
   -e GITHUB_ACCOUNT=my_account_name \
   -e GITHUB_AUTH_TYPE=pat \
   -e GITHUB_TOKEN=my_token \
+  -e GITHUB_LOG_LEVEL=4 \
   prometheus-gh-rate-limit-exporter:latest
 ```
 
@@ -103,6 +104,7 @@ docker run -p 10050:10050 -d \
   -e GITHUB_APP_ID=111111 \
   -e GITHUB_APP_INSTALLATION_ID=22222222 \
   -e GITHUB_APP_PRIVATE_KEY_PATH=/app/key.pem \
+  -e GITHUB_LOG_LEVEL=4 \
   --mount type=bind,source=/ws/key.pem,target=/app/key.pem,readonly \
   prometheus-gh-rate-limit-exporter:latest
 ```
@@ -124,6 +126,7 @@ pip install --user tox
 export GITHUB_AUTH_TYPE=pat
 export GITHUB_TOKEN=your_token
 export GITHUB_ACCOUNT=your_account
+export GITHUB_LOG_LEVEL=4
 export GF_SECURITY_ADMIN_USER=username
 export GF_SECURITY_PASSWORD=password
 tox -e dc-run
@@ -137,6 +140,7 @@ export GITHUB_APP_ID=12345
 export GITHUB_APP_INSTALLATION_ID=123456
 export GITHUB_APP_SRC_PRIVATE_KEY_PATH=/ws/private_key.pem
 export GITHUB_APP_PRIVATE_KEY_PATH=/tmp/private_key.pem
+export GITHUB_LOG_LEVEL=4
 export GF_SECURITY_ADMIN_USER=username
 export GF_SECURITY_PASSWORD=password
 tox -e dc-run

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       GITHUB_APP_INSTALLATION_ID: null
       GITHUB_APP_PRIVATE_KEY_PATH: ${GITHUB_APP_PRIVATE_KEY_PATH:-/tmp/private-key.pem}
       GITHUB_APP_SRC_PRIVATE_KEY_PATH: ${GITHUB_APP_SRC_PRIVATE_KEY_PATH:-/dev/null}
+      GITHUB_LOG_LEVEL: null
     volumes:
       - ${GITHUB_APP_SRC_PRIVATE_KEY_PATH:-/dev/null}:${GITHUB_APP_PRIVATE_KEY_PATH:-/tmp/private-key.pem}:ro
     networks:

--- a/github_rate_limits_exporter/cli.py
+++ b/github_rate_limits_exporter/cli.py
@@ -89,9 +89,12 @@ def parsecli(
     parser.add_argument(
         "-v",
         dest="verbosity",
-        default=0,
+        default=os.getenv("GITHUB_LOG_LEVEL") or 3,
         action="count",
-        help="Increase verbosity level (-vv for more)",
+        help=(
+            "Increase (-v) the logging verbosity level (up to 5 times),"
+            "default level: INFO."
+        ),
     )
     args, __ = parser.parse_known_args(args=argv)
     _check_mutual_inclusive_arguments(args, parser)

--- a/github_rate_limits_exporter/utils.py
+++ b/github_rate_limits_exporter/utils.py
@@ -69,7 +69,7 @@ def initialize_logger(level: int) -> None:
     console = logging.StreamHandler(sys.stdout)
     template = logging.Formatter(DEFAULT_LOG_FMT)
     console.setFormatter(template)
-    verbosity_level = levels.get(level, logging.DEBUG)
+    verbosity_level = levels.get(int(level), logging.DEBUG)
     logger = logging.getLogger()
     logger.addHandler(console)
     logger.setLevel(verbosity_level)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -79,10 +79,12 @@ def test_mutual_inclusive_args(namespace, argparser, expectation):
     {
      'GITHUB_AUTH_TYPE': 'pat',
      'GITHUB_TOKEN': 'token',
-     'GITHUB_ACCOUNT': 'test'
+     'GITHUB_ACCOUNT': 'test',
+     'GITHUB_LOG_LEVEL': '4'
     }], indirect=True)
 def test_github_pat_auth_env_variables(github_env_vars):
     args = cli.parsecli(['--listen-port', '5000'])
     assert args.github_account == github_env_vars['GITHUB_ACCOUNT']
     assert args.github_auth_type == github_env_vars['GITHUB_AUTH_TYPE']
     assert args.github_token == github_env_vars['GITHUB_TOKEN']
+    assert args.verbosity == github_env_vars['GITHUB_LOG_LEVEL']

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,7 @@ passenv =
     GITHUB_APP_INSTALLATION_ID
     GITHUB_APP_PRIVATE_KEY_PATH
     GITHUB_APP_SRC_PRIVATE_KEY_PATH
+    GITHUB_LOG_LEVEL
 
 
 [dc-base]
@@ -162,7 +163,7 @@ commands =
     allure serve {toxinidir}/.allure --port {posargs:8200}
 
 
-[testenv:run]
+[testenv:run-exporter]
 description = Start prometheus exporter as service
 passenv = {[base]passenv}
 commands =


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

add GITHUB_LOG_LEVEL environment variable to override the command line verbosity option (-v).
GITHUB_LOG_LEVEL takes precendence over command line verbosity option (-v).  
Set default log level to INFO if GITHUB_LOG_LEVEL is not defined.

#### Related Issues
<!--- Does this relate to any issues? -->
Addresses 
