### PR TITLE
feat: add support for token expiration logging

### DIFF
--- a/github_rate_limits_exporter/__init__.py
+++ b/github_rate_limits_exporter/__init__.py
@@ -14,6 +14,7 @@
 """
 
 import argparse
+import datetime
 import logging
 import time
 from typing import List, Optional
@@ -23,20 +24,25 @@ from prometheus_client import REGISTRY, start_http_server
 from github_rate_limits_exporter.cli import parsecli
 from github_rate_limits_exporter.collector import GithubRateLimitsCollector
 from github_rate_limits_exporter.exceptions import ERROR_STATUS_ON_EXCEPTIONS
-from github_rate_limits_exporter.github import GithubApp
-from github_rate_limits_exporter.utils import GracefulShutdown, initialize_logger
+from github_rate_limits_exporter.github import AccessToken, GithubApp
+from github_rate_limits_exporter.utils import (
+    GracefulShutdown,
+    extend_datetime_now,
+    initialize_logger,
+)
 
 logger = logging.getLogger(__name__)
 
 
-def _get_access_token(args: argparse.Namespace) -> str:
+def _get_access_token(args: argparse.Namespace) -> AccessToken:
     if args.github_auth_type == "pat":
-        return args.github_token
-    return GithubApp(
+        return AccessToken(args.github_token, extend_datetime_now(weeks=999))
+    token = GithubApp(
         args.github_app_id,
         args.github_app_private_key_path,
         args.github_app_installation_id,
     ).access_token
+    return AccessToken(token.token, token.expires_at)
 
 
 def main(argv: Optional[List[str]] = None) -> int:
@@ -46,7 +52,10 @@ def main(argv: Optional[List[str]] = None) -> int:
         initialize_logger(args.verbosity)
         logger.info('Register collector for "%s" Github account', args.github_account)
         access_token = _get_access_token(args)
-        REGISTRY.register(GithubRateLimitsCollector(args.github_account, access_token))
+        logger.debug(access_token)
+        REGISTRY.register(
+            GithubRateLimitsCollector(args.github_account, access_token.token)
+        )
         logger.info(
             "HTTP metrics server started on [%s:%d]", args.bind_addr, args.listen_port
         )

--- a/github_rate_limits_exporter/utils.py
+++ b/github_rate_limits_exporter/utils.py
@@ -125,3 +125,14 @@ def is_ipv6_addr(ip_addr: str) -> bool:
     except socket.error:
         return False
     return True
+
+
+def extend_datetime_now(weeks: int = 1) -> datetime.datetime:
+    """
+    Extend the current date in UTC by X number of weeks.
+
+    :params int weeks: Number of weeks
+    :returns datetime.datetime: The current datetime object extend by X weeks.
+    """
+    now = datetime.datetime.utcnow()
+    return now + datetime.timedelta(weeks=weeks)

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1,6 +1,9 @@
+from datetime import datetime
+import iso8601
 import pytest
 from contextlib import nullcontext as does_not_raise
-from github_rate_limits_exporter.github import GithubApp
+from github_rate_limits_exporter.github import GithubApp, AccessToken
+from tests.utils import CURRENT_TIME
 
 
 @pytest.mark.parametrize('private_key, expectation', [
@@ -43,3 +46,12 @@ def test_github_app_installation_id(install_id, expectation, request):
             request.getfixturevalue('private_key_str'),
             install_id
         )
+
+
+@pytest.mark.parametrize('token, expires_at, expectation', [
+    ('value', CURRENT_TIME, does_not_raise()),
+    ('another_value', 'date', pytest.raises(ValueError))
+])
+def test_access_token(token, expires_at, expectation):
+    with expectation:
+         AccessToken(token, expires_at)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

add token expiration logging when github authentication type is ``pat`` or ``app``,  
introduce ``class Access_Token`` to create a common interface for pat or app access tokens.

#### Related Issues
<!--- Does this relate to any issues? -->
Addresses 
