### PR TITLE
feat: handle exceptions from daemon to main thread

### DIFF
--- a/github_rate_limits_exporter/exceptions.py
+++ b/github_rate_limits_exporter/exceptions.py
@@ -6,6 +6,8 @@
 """
 
 from github import GithubException
+from requests import RequestException
+from urllib3.exceptions import HTTPError
 
 
 class Error(Exception):
@@ -19,4 +21,11 @@ class ArgumentError(Error):
     """An error from creating or using an argument"""
 
 
-ERROR_STATUS_ON_EXCEPTIONS = (Error, ValueError, GithubException)
+# Those exceptions will be handle gracefully by the main thread.
+ERROR_STATUS_ON_EXCEPTIONS = (
+    Error,
+    ValueError,
+    GithubException,
+    RequestException,
+    HTTPError,
+)

--- a/requirements.d/isort.txt
+++ b/requirements.d/isort.txt
@@ -1,2 +1,3 @@
 # Requirements for [testenv:isort] virtualenv
-isort==5.11.4
+isort==5.11.4; python_version <= "3.7"
+isort==5.12.0; python_version > "3.7"

--- a/requirements.d/mypy.txt
+++ b/requirements.d/mypy.txt
@@ -1,3 +1,4 @@
 # Requirements for [testenv:mypy] virtualenv
 
 mypy==0.991
+types-requests==2.28.11.8

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -89,3 +89,15 @@ def test_extended_datetime_now(freezer):
     freezer.move_to("2023-01-15")
     expected = datetime.datetime(2023, 1, 22)
     assert extend_datetime_now(weeks=1) == expected
+
+
+def test_shared_exception_queue_put(exception_queue, exception_queue_put_error):
+    value = exception_queue_put_error()
+    assert value is None
+    assert str(exception_queue.get(block=False)) == "invalid value"
+
+
+def test_shared_exception_queue_get_error(exception_queue, exception_queue_put_error):
+    exception_queue_put_error()
+    with pytest.raises(ValueError):
+        exception_queue.get_error()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

Add queue to communicate exceptions from daemon thread to main thread, when exception is raised from daemon to main thread then exception will be handle appropriately (exit status 1) on the main program and other third party tools such as: kubelet, docker daemon will restart the exporter in case of graceful failures.

#### Related Issues
<!--- Does this relate to any issues? -->
Addresses 
