### PR TITLE
fix: is_string_base64_encoded utility function

### DIFF
--- a/github_rate_limits_exporter/utils.py
+++ b/github_rate_limits_exporter/utils.py
@@ -9,6 +9,7 @@ import base64
 import binascii
 import datetime
 import logging
+import os
 import queue
 import signal
 import socket
@@ -36,7 +37,9 @@ def is_string_base64_encoded(string: str) -> bool:
     :returns bool: ``True`` if base64 encoded else ``False``.
     """
     try:
-        return base64.b64encode(base64.b64decode(string)).decode() == string
+        return base64.b64encode(base64.b64decode(string)).decode() == string.replace(
+            os.linesep, ""
+        )
     except binascii.Error:
         return False
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+import os
 
 import pytest
 
@@ -48,14 +49,19 @@ def test_is_ipv6_address(ipv6_addr, expected):
 
 @pytest.mark.parametrize(
     "string, expected",
-    [("teststring", False), ("dGVzdHN0cmluZwo=", True), ("3591916071403198536", False)],
+    [
+        ("teststring", False),
+        ("dGVzdHN0cmluZwo=", True),
+        ("3591916071403198536", False),
+        (f"RU5E{os.linesep}IFJTQSBQUklWQVRFIEtFWS0tLS0tCg=={os.linesep}", True),
+    ],
 )
 def test_is_string_base64_encoded(string, expected):
     assert is_string_base64_encoded(string) == expected
 
 
 @pytest.mark.parametrize(
-    "string, expected", [("teststring", "teststring"), ("dGVzdHN0cmluZwo=", "teststring\n")]
+    "string, expected", [("teststring", "teststring"), ("dGVzdHN0cmluZwo=", f"teststring{os.linesep}")]
 )
 def test_base64_decode(string, expected):
     assert base64_decode(string) == expected


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

Exporter was getting crashed when the private key was base64 encoded, newlines was stripped off by the ``base64.b64encode`` function while comparing the original string with the existing newlines resulting to ``False`` evaluation even if the string was base64 encoded.

#### Related Issues
<!--- Does this relate to any issues? -->
Addresses 
