### PR TITLE
feat(chart): add liveness probe

### DIFF
--- a/charts/github-rate-limits-exporter/templates/deployment.yaml
+++ b/charts/github-rate-limits-exporter/templates/deployment.yaml
@@ -92,6 +92,9 @@ spec:
             httpGet:
               path: /metrics
               port: metrics
+          livenessProbe:
+            tcpSocket:
+              port: metrics
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- if eq (lower (.Values.exporter.github.authType | default "")) "app" }}

--- a/charts/github-rate-limits-exporter/templates/deployment.yaml
+++ b/charts/github-rate-limits-exporter/templates/deployment.yaml
@@ -92,9 +92,11 @@ spec:
             httpGet:
               path: /metrics
               port: metrics
+            initialDelaySeconds: 10
           livenessProbe:
             tcpSocket:
               port: metrics
+            initialDelaySeconds: 10
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- if eq (lower (.Values.exporter.github.authType | default "")) "app" }}

--- a/charts/github-rate-limits-exporter/unittests/deployment-test.yaml
+++ b/charts/github-rate-limits-exporter/unittests/deployment-test.yaml
@@ -73,6 +73,11 @@ tests:
                   httpGet:
                     path: /metrics
                     port: metrics
+                  initialDelaySeconds: 10
+                livenessProbe:
+                  tcpSocket:
+                    port: metrics
+                  initialDelaySeconds: 10
                 resources:
                   limits:
                     cpu: 100m

--- a/charts/github-rate-limits-exporter/unittests/deployment-test.yaml
+++ b/charts/github-rate-limits-exporter/unittests/deployment-test.yaml
@@ -229,6 +229,11 @@ tests:
               httpGet:
                 path: /metrics
                 port: metrics
+              initialDelaySeconds: 10
+            livenessProbe:
+              tcpSocket:
+                port: metrics
+              initialDelaySeconds: 10
             resources:
               requests:
                 cpu: 100m


### PR DESCRIPTION
## Description

Add a livenessProbe in the chart, using a simple one: tcpSocket.

## Motivation

Follow kubernetes best practices on probes.