### PR TITLE
feat(chart): add probes.enabled toggle to opt out of liveness and readiness probes

### DIFF
--- a/charts/github-rate-limits-exporter/templates/deployment.yaml
+++ b/charts/github-rate-limits-exporter/templates/deployment.yaml
@@ -88,6 +88,7 @@ spec:
             - name: metrics
               containerPort: {{ .Values.exporter.port | int }}
               protocol: TCP
+          {{- if .Values.probes.enabled }}
           readinessProbe:
             httpGet:
               path: /metrics
@@ -97,6 +98,7 @@ spec:
             tcpSocket:
               port: metrics
             initialDelaySeconds: 10
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- if eq (lower (.Values.exporter.github.authType | default "")) "app" }}

--- a/charts/github-rate-limits-exporter/unittests/deployment-test.yaml
+++ b/charts/github-rate-limits-exporter/unittests/deployment-test.yaml
@@ -306,3 +306,20 @@ tests:
                 secretKeyRef:
                   name: gh-rl-exporter
                   key: token
+  - it: probes are rendered by default
+    template: deployment.yaml
+    asserts:
+      - isNotNull:
+          path: spec.template.spec.containers[0].readinessProbe
+      - isNotNull:
+          path: spec.template.spec.containers[0].livenessProbe
+  - it: probes can be disabled
+    template: deployment.yaml
+    set:
+      probes:
+        enabled: false
+    asserts:
+      - isNull:
+          path: spec.template.spec.containers[0].readinessProbe
+      - isNull:
+          path: spec.template.spec.containers[0].livenessProbe

--- a/charts/github-rate-limits-exporter/values.yaml
+++ b/charts/github-rate-limits-exporter/values.yaml
@@ -34,6 +34,16 @@ imagePullSecrets: []
 serviceMonitor:
   enabled: false
   annotations: {}
+# Liveness and readiness probes for the exporter container.
+# The readiness probe scrapes the same /metrics endpoint Prometheus does,
+# which means every probe causes a real Github API rate-limit call. For
+# deployments where Prometheus already records scrape errors and you would
+# rather not double the load on Github's rate-limit endpoint (or burn
+# tokens against a private GHE quota), set this to false. The exporter is
+# stateless and Prometheus's scrape-error metrics are sufficient for
+# alerting in that case.
+probes:
+  enabled: true
 resources:
   limits:
     cpu: 100m


### PR DESCRIPTION
## Motivation

The chart's default `readinessProbe` is an `httpGet` against `/metrics`. Every probe causes a real Github API call to `/rate_limit`, in addition to whatever Prometheus is already doing. With the kubelet's default `periodSeconds: 10`, that's ~8,640 probe-induced API calls per pod per day, which is wasteful in two ways:

- **Burns rate-limit budget on a private GHE quota or a bot's PAT for no useful signal.**
- **Doubles load on `/rate_limit` itself** — Prometheus is already scraping the same endpoint at whatever interval the operator configured.

The exporter is stateless. Prometheus already records scrape errors (`up{job=...}=0`, `scrape_samples_scraped` etc.); alerting on those is strictly more informative than the kubelet flipping `Ready=false`, because it's the same signal Prometheus is already producing for every other target.

For this kind of exporter, kubelet probes don't add information — they just add load.

## Change

Adds a single `probes.enabled` toggle (defaults to `true` — no behaviour change for existing users):

```yaml
probes:
  enabled: true   # default; flip to false to drop liveness + readiness
```

When set to `false`, both `readinessProbe` and `livenessProbe` are omitted from the pod spec.

## Why bundle liveness and readiness behind one toggle

The two probes are conceptually a pair: if you trust scrape errors enough to drop the readiness probe, the liveness probe (`tcpSocket`) is also unnecessary — the same signal that says "the metrics endpoint is broken" will eventually result in either Prometheus alerting or the pod being noticed. Splitting them adds API surface for a distinction that doesn't matter in practice. If a need arises later for independent toggles, this can be split without breaking compatibility.

## Verification

`helm template` smoke tests:

```
$ helm template t ./charts/github-rate-limits-exporter --set probes.enabled=false ... | grep -cE 'readinessProbe|livenessProbe'
0

$ helm template t ./charts/github-rate-limits-exporter ... | grep -cE 'readinessProbe|livenessProbe'
2
```

Two new chart unit tests cover both states (`probes are rendered by default`, `probes can be disabled`).

## Independence

This is an isolated chart change. Doesn't depend on or conflict with #1043 (raw_data fix), #1044 (GHE support), or #1046 (CRD removal).