### PR TITLE
feat(chart): support referencing an existing Secret for GitHub credentials

### DIFF
--- a/charts/github-rate-limits-exporter/templates/deployment.yaml
+++ b/charts/github-rate-limits-exporter/templates/deployment.yaml
@@ -51,7 +51,7 @@ spec:
             - name: GITHUB_ACCOUNT
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "github-rate-limits-exporter.fullname" . }}
+                  name: {{ default (include "github-rate-limits-exporter.fullname" .) .Values.exporter.github.existingSecret }}
                   key: accountName
             - name: GITHUB_AUTH_TYPE
               value: {{ .Values.exporter.github.authType | lower | quote }}
@@ -68,12 +68,12 @@ spec:
             - name: GITHUB_APP_ID
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "github-rate-limits-exporter.fullname" . }}
+                  name: {{ default (include "github-rate-limits-exporter.fullname" .) .Values.exporter.github.existingSecret }}
                   key: appID
             - name: GITHUB_APP_INSTALLATION_ID
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "github-rate-limits-exporter.fullname" . }}
+                  name: {{ default (include "github-rate-limits-exporter.fullname" .) .Values.exporter.github.existingSecret }}
                   key: installationID
             - name: GITHUB_APP_PRIVATE_KEY_PATH
               value: {{ printf "%s/privateKey" .Values.exporter.github.mountPath }}
@@ -81,7 +81,7 @@ spec:
             - name: GITHUB_ACCOUNT
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "github-rate-limits-exporter.fullname" . }}
+                  name: {{ default (include "github-rate-limits-exporter.fullname" .) .Values.exporter.github.existingSecret }}
                   key: accountName
             - name: GITHUB_AUTH_TYPE
               value: {{ .Values.exporter.github.authType | lower | quote }}
@@ -98,7 +98,7 @@ spec:
             - name: GITHUB_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "github-rate-limits-exporter.fullname" . }}
+                  name: {{ default (include "github-rate-limits-exporter.fullname" .) .Values.exporter.github.existingSecret }}
                   key: token
           {{- end }}
           {{- if or (eq (lower (.Values.exporter.github.authType | default "")) "app") .Values.exporter.github.caBundle }}
@@ -137,7 +137,7 @@ spec:
         {{- if eq (lower (.Values.exporter.github.authType | default "")) "app" }}
         - name: app-private-key
           secret:
-            secretName: {{ template "github-rate-limits-exporter.fullname" . }}
+            secretName: {{ default (include "github-rate-limits-exporter.fullname" .) .Values.exporter.github.existingSecret }}
         {{- end }}
         {{- if .Values.exporter.github.caBundle }}
         - name: ca-bundle

--- a/charts/github-rate-limits-exporter/templates/deployment.yaml
+++ b/charts/github-rate-limits-exporter/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
             - name: GITHUB_ACCOUNT
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "github-rate-limits-exporter.fullname" . }}
+                  name: {{ default (include "github-rate-limits-exporter.fullname" .) .Values.exporter.github.existingSecret }}
                   key: accountName
             - name: GITHUB_AUTH_TYPE
               value: {{ .Values.exporter.github.authType | lower | quote }}
@@ -63,12 +63,12 @@ spec:
             - name: GITHUB_APP_ID
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "github-rate-limits-exporter.fullname" . }}
+                  name: {{ default (include "github-rate-limits-exporter.fullname" .) .Values.exporter.github.existingSecret }}
                   key: appID
             - name: GITHUB_APP_INSTALLATION_ID
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "github-rate-limits-exporter.fullname" . }}
+                  name: {{ default (include "github-rate-limits-exporter.fullname" .) .Values.exporter.github.existingSecret }}
                   key: installationID
             - name: GITHUB_APP_PRIVATE_KEY_PATH
               value: {{ printf "%s/privateKey" .Values.exporter.github.mountPath }}
@@ -76,7 +76,7 @@ spec:
             - name: GITHUB_ACCOUNT
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "github-rate-limits-exporter.fullname" . }}
+                  name: {{ default (include "github-rate-limits-exporter.fullname" .) .Values.exporter.github.existingSecret }}
                   key: accountName
             - name: GITHUB_AUTH_TYPE
               value: {{ .Values.exporter.github.authType | lower | quote }}
@@ -93,7 +93,7 @@ spec:
             - name: GITHUB_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "github-rate-limits-exporter.fullname" . }}
+                  name: {{ default (include "github-rate-limits-exporter.fullname" .) .Values.exporter.github.existingSecret }}
                   key: token
           {{- end }}
           {{- if or (eq (lower (.Values.exporter.github.authType | default "")) "app") .Values.exporter.github.caBundle }}
@@ -132,7 +132,7 @@ spec:
         {{- if eq (lower (.Values.exporter.github.authType | default "")) "app" }}
         - name: app-private-key
           secret:
-            secretName: {{ template "github-rate-limits-exporter.fullname" . }}
+            secretName: {{ default (include "github-rate-limits-exporter.fullname" .) .Values.exporter.github.existingSecret }}
         {{- end }}
         {{- if .Values.exporter.github.caBundle }}
         - name: ca-bundle

--- a/charts/github-rate-limits-exporter/templates/secret.yaml
+++ b/charts/github-rate-limits-exporter/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.exporter.github.existingSecret }}
 ---
 apiVersion: v1
 kind: Secret
@@ -23,3 +24,4 @@ data:
   privateKey: {{ .Values.exporter.github.privateKey | b64enc | quote }}
   {{- end }}
 ...
+{{- end }}

--- a/charts/github-rate-limits-exporter/templates/secret.yaml
+++ b/charts/github-rate-limits-exporter/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.exporter.github.existingSecret }}
 ---
 apiVersion: v1
 kind: Secret
@@ -22,3 +23,4 @@ data:
   privateKey: {{ .Values.exporter.github.privateKey | b64enc | quote }}
   {{- end }}
 ...
+{{- end }}

--- a/charts/github-rate-limits-exporter/unittests/deployment-test.yaml
+++ b/charts/github-rate-limits-exporter/unittests/deployment-test.yaml
@@ -311,6 +311,74 @@ tests:
                 secretKeyRef:
                   name: gh-rl-exporter
                   key: token
+  - it: app credentials are read from existingSecret
+    template: deployment.yaml
+    set:
+      fullnameOverride: gh-rl-exporter
+      exporter:
+        github:
+          accountName: theodore86
+          authType: app
+          mountPath: /secret
+          existingSecret: my-github-app-secret
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env
+          value:
+            - name: GITHUB_ACCOUNT
+              valueFrom:
+                secretKeyRef:
+                  name: my-github-app-secret
+                  key: accountName
+            - name: GITHUB_AUTH_TYPE
+              value: app
+            - name: EXPORTER_LOG_LEVEL
+              value: "4"
+            - name: GITHUB_APP_ID
+              valueFrom:
+                secretKeyRef:
+                  name: my-github-app-secret
+                  key: appID
+            - name: GITHUB_APP_INSTALLATION_ID
+              valueFrom:
+                secretKeyRef:
+                  name: my-github-app-secret
+                  key: installationID
+            - name: GITHUB_APP_PRIVATE_KEY_PATH
+              value: /secret/privateKey
+      - equal:
+          path: spec.template.spec.volumes
+          value:
+            - name: app-private-key
+              secret:
+                secretName: my-github-app-secret
+  - it: pat token is read from existingSecret
+    template: deployment.yaml
+    set:
+      fullnameOverride: gh-rl-exporter
+      exporter:
+        github:
+          accountName: theodore86
+          authType: pat
+          existingSecret: my-github-pat-secret
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env
+          value:
+            - name: GITHUB_ACCOUNT
+              valueFrom:
+                secretKeyRef:
+                  name: my-github-pat-secret
+                  key: accountName
+            - name: GITHUB_AUTH_TYPE
+              value: pat
+            - name: EXPORTER_LOG_LEVEL
+              value: "4"
+            - name: GITHUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: my-github-pat-secret
+                  key: token
   - it: probes are rendered by default
     template: deployment.yaml
     asserts:

--- a/charts/github-rate-limits-exporter/unittests/deployment-test.yaml
+++ b/charts/github-rate-limits-exporter/unittests/deployment-test.yaml
@@ -306,6 +306,74 @@ tests:
                 secretKeyRef:
                   name: gh-rl-exporter
                   key: token
+  - it: app credentials are read from existingSecret
+    template: deployment.yaml
+    set:
+      fullnameOverride: gh-rl-exporter
+      exporter:
+        github:
+          accountName: theodore86
+          authType: app
+          mountPath: /secret
+          existingSecret: my-github-app-secret
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env
+          value:
+            - name: GITHUB_ACCOUNT
+              valueFrom:
+                secretKeyRef:
+                  name: my-github-app-secret
+                  key: accountName
+            - name: GITHUB_AUTH_TYPE
+              value: app
+            - name: EXPORTER_LOG_LEVEL
+              value: "4"
+            - name: GITHUB_APP_ID
+              valueFrom:
+                secretKeyRef:
+                  name: my-github-app-secret
+                  key: appID
+            - name: GITHUB_APP_INSTALLATION_ID
+              valueFrom:
+                secretKeyRef:
+                  name: my-github-app-secret
+                  key: installationID
+            - name: GITHUB_APP_PRIVATE_KEY_PATH
+              value: /secret/privateKey
+      - equal:
+          path: spec.template.spec.volumes
+          value:
+            - name: app-private-key
+              secret:
+                secretName: my-github-app-secret
+  - it: pat token is read from existingSecret
+    template: deployment.yaml
+    set:
+      fullnameOverride: gh-rl-exporter
+      exporter:
+        github:
+          accountName: theodore86
+          authType: pat
+          existingSecret: my-github-pat-secret
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env
+          value:
+            - name: GITHUB_ACCOUNT
+              valueFrom:
+                secretKeyRef:
+                  name: my-github-pat-secret
+                  key: accountName
+            - name: GITHUB_AUTH_TYPE
+              value: pat
+            - name: EXPORTER_LOG_LEVEL
+              value: "4"
+            - name: GITHUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: my-github-pat-secret
+                  key: token
   - it: probes are rendered by default
     template: deployment.yaml
     asserts:

--- a/charts/github-rate-limits-exporter/unittests/secret-test.yaml
+++ b/charts/github-rate-limits-exporter/unittests/secret-test.yaml
@@ -57,3 +57,13 @@ tests:
           - equal:
                 path: data.privateKey
                 value: dHczSnJLSWpGeElNQmQ5UStEeHFtTVg0ZjhSbzZOR0RRWmtiL0k1akM4NFJTdFJOd242dmJRNWtrOFB0aER6SQo=
+    - it: is not rendered when existingSecret is set
+      set:
+          exporter:
+              github:
+                  accountName: theodore86
+                  authType: app
+                  existingSecret: my-github-app-secret
+      asserts:
+          - hasDocuments:
+                count: 0

--- a/charts/github-rate-limits-exporter/values.yaml
+++ b/charts/github-rate-limits-exporter/values.yaml
@@ -34,6 +34,19 @@ exporter:
   #     -----BEGIN CERTIFICATE-----
   #     ...
   #     -----END CERTIFICATE-----
+  #
+  # To reference a Secret provisioned out-of-band (e.g. by a secrets operator)
+  # instead of having the chart create one from the values above, set
+  # existingSecret to its name. The chart will not render its own Secret and
+  # will point every credential reference at the named one. The Secret must
+  # expose the same keys the chart would otherwise create:
+  #   PAT: accountName, token
+  #   APP: accountName, appID, installationID, privateKey
+  # github:
+  #   authType: app
+  #   mountPath: /secret
+  #   existingSecret: my-github-credentials
+  #
   github: {}
 service:
   clusterIP: ""

--- a/charts/github-rate-limits-exporter/values.yaml
+++ b/charts/github-rate-limits-exporter/values.yaml
@@ -34,6 +34,7 @@ exporter:
   #     -----BEGIN CERTIFICATE-----
   #     ...
   #     -----END CERTIFICATE-----
+  #
   github: {}
 service:
   clusterIP: ""


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

Add exporter.github.existingSecret. When set, the chart no longer
renders its own Secret and instead points every GitHub credential
reference in the Deployment (env secretKeyRefs and the app private-key
volume) at the named Secret. This lets credentials be provisioned
out-of-band (e.g. by a secrets operator) rather than passed through
values.yaml.

The referenced Secret must expose the same keys the chart would
otherwise create:
  - PAT: accountName, token
  - APP: accountName, appID, installationID, privateKey

#### Related Issues
<!--- Does this relate to any issues? -->

N/A
